### PR TITLE
Don't assume `window` on initial execution

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -614,7 +614,9 @@ function Swipe(container, options) {
 
 }
 
-var jsLib = window.jQuery || window.Zepto;  // jQuery or Zepto
+var jsLib = typeof window === 'object' ?
+  window.jQuery || window.Zepto : // jQuery or Zepto
+  false;
  
 if ( jsLib ) {
   (function($) {


### PR DESCRIPTION
I want to load this script in Node.js so that I can prerender some React components that depend on Swipe. It blows up when we start testing for stuff on `window`.

(I use your fork for the performance fixes, so I figured I would submit a PR so I can continue using this fork, etc)
